### PR TITLE
Enable Frame Number Slider to Work with Multiple Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ output
 temp
 config.yaml
 run.bat
+venv

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -80,7 +80,11 @@ def run():
     
     run_server = True
     mycss = """
-        span {color: var(--block-info-text-color)}        
+        span {color: var(--block-info-text-color)}
+        #filelist {
+            max-height: 238.4px;
+            overflow-y: auto !important;
+        }
 """
 
     while run_server:


### PR DESCRIPTION
This pull request enhances the functionality of the frame slider, enabling it to act as a file selector when the target files are images. This allows users to preview multiple images, both with and without the swap.

Additionally, the overflow issue has been addressed through CSS adjustments.

I noticed an issue when handling a large number of files: moving the slider multiple times in quick succession can lead to a discrepancy between the frame number displayed and the actual picture shown. It seems that the second slider movement doesn't cancel the previous `on_preview_frame_changed` call nor queue up a second call, causing this misalignment. While the issue can be resolved by clicking the refresh button, I didn't have the opportunity to investigate a permanent fix in this pull request. 

If there are specific guidelines or preferences for how this should be done, please let me know, and I'll be happy to make any necessary refinements. Your feedback is appreciated!