### PR TITLE
Add output template support

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -369,11 +369,16 @@ def batch_process(files, use_clip, new_clip_text, use_new_method) -> None:
                     util.create_gif_from_video(video_file_name, destination)
                     if os.path.isfile(destination):
                         os.remove(video_file_name)
-                elif not roop.globals.skip_audio:
+                else:
+                    skip_audio = roop.globals.skip_audio
                     destination = util.replace_template(video_file_name)
-                    util.restore_audio(video_file_name, v, destination)
-                    if os.path.isfile(destination):
-                        os.remove(video_file_name)
+
+                    if not skip_audio:
+                        util.restore_audio(video_file_name, v, destination)
+                        if os.path.isfile(destination):
+                            os.remove(video_file_name)
+                    else:
+                        shutil.move(video_file_name, destination)
                 update_status(f'\nProcessing {os.path.basename(destination)} took {time() - start_processing} secs')
 
             else:

--- a/roop/core.py
+++ b/roop/core.py
@@ -309,12 +309,15 @@ def batch_process(files, use_clip, new_clip_text, use_new_method) -> None:
             fullname = os.path.join(roop.globals.target_folder_path, f)
         else:
             fullname = f
+
         if util.has_image_extension(fullname):
             imagefiles.append(fullname)
-            imagefinalnames.append(util.get_destfilename_from_path(fullname, roop.globals.output_path, f'_fake.{roop.globals.CFG.output_image_format}'))
+            destination = util.get_destfilename_from_path(fullname, roop.globals.output_path, f'.{roop.globals.CFG.output_image_format}')
+            imagefinalnames.append(util.replace_template(destination))
         elif util.is_video(fullname) or util.has_extension(fullname, ['gif']):
             videofiles.append(fullname)
-            videofinalnames.append(util.get_destfilename_from_path(fullname, roop.globals.output_path, f'_fake.{roop.globals.CFG.output_video_format}'))
+            destination = util.get_destfilename_from_path(fullname, roop.globals.output_path, f'__temp.{roop.globals.CFG.output_video_format}')
+            videofinalnames.append(destination)
 
 
     if(len(imagefiles) > 0):
@@ -356,20 +359,25 @@ def batch_process(files, use_clip, new_clip_text, use_new_method) -> None:
                 end_processing('Processing stopped!')
                 return
             
-            if os.path.isfile(videofinalnames[index]):
+            video_file_name = videofinalnames[index]
+            if os.path.isfile(video_file_name):
+                destination = ''
                 if util.has_extension(v, ['gif']):
-                    gifname = util.get_destfilename_from_path(v, './output', '_fake.gif')
+                    gifname = util.get_destfilename_from_path(v, './output', '.gif')
+                    destination = util.replace_template(gifname)
                     update_status('Creating final GIF')
-                    util.create_gif_from_video(videofinalnames[index], gifname)
+                    util.create_gif_from_video(video_file_name, destination)
+                    if os.path.isfile(destination):
+                        os.remove(video_file_name)
                 elif not roop.globals.skip_audio:
-                    finalname = util.get_destfilename_from_path(videofinalnames[index], roop.globals.output_path, f'_final.{roop.globals.CFG.output_video_format}')
-                    util.restore_audio(videofinalnames[index], v, finalname)
-                    if os.path.isfile(finalname):
-                        os.remove(videofinalnames[index])
-                update_status(f'\nProcessing {os.path.basename(videofinalnames[index])} took {time() - start_processing} secs')
+                    destination = util.replace_template(video_file_name)
+                    util.restore_audio(video_file_name, v, destination)
+                    if os.path.isfile(destination):
+                        os.remove(video_file_name)
+                update_status(f'\nProcessing {os.path.basename(destination)} took {time() - start_processing} secs')
 
             else:
-                update_status(f'Failed processing {os.path.basename(videofinalnames[index])}!')
+                update_status(f'Failed processing {os.path.basename(video_file_name)}!')
             release_resources()
     end_processing('Finished')
 

--- a/roop/core.py
+++ b/roop/core.py
@@ -14,6 +14,7 @@ import signal
 import argparse
 import torch
 import onnxruntime
+import pathlib
 #import tensorflow
 
 from time import time
@@ -304,7 +305,7 @@ def batch_process(files, use_clip, new_clip_text, use_new_method) -> None:
         update_status('Sorting videos/images')
 
 
-    for f in files:
+    for index, f in enumerate(files):
         if need_join:
             fullname = os.path.join(roop.globals.target_folder_path, f)
         else:
@@ -313,7 +314,7 @@ def batch_process(files, use_clip, new_clip_text, use_new_method) -> None:
         if util.has_image_extension(fullname):
             imagefiles.append(fullname)
             destination = util.get_destfilename_from_path(fullname, roop.globals.output_path, f'.{roop.globals.CFG.output_image_format}')
-            imagefinalnames.append(util.replace_template(destination))
+            imagefinalnames.append(util.replace_template(destination, index=index))
         elif util.is_video(fullname) or util.has_extension(fullname, ['gif']):
             videofiles.append(fullname)
             destination = util.get_destfilename_from_path(fullname, roop.globals.output_path, f'__temp.{roop.globals.CFG.output_video_format}')
@@ -364,14 +365,18 @@ def batch_process(files, use_clip, new_clip_text, use_new_method) -> None:
                 destination = ''
                 if util.has_extension(v, ['gif']):
                     gifname = util.get_destfilename_from_path(v, './output', '.gif')
-                    destination = util.replace_template(gifname)
+                    destination = util.replace_template(gifname, index=index)
+
+                    pathlib.Path(os.path.dirname(destination)).mkdir(parents=True, exist_ok=True)
+
                     update_status('Creating final GIF')
                     util.create_gif_from_video(video_file_name, destination)
                     if os.path.isfile(destination):
                         os.remove(video_file_name)
                 else:
                     skip_audio = roop.globals.skip_audio
-                    destination = util.replace_template(video_file_name)
+                    destination = util.replace_template(video_file_name, index=index)
+                    pathlib.Path(os.path.dirname(destination)).mkdir(parents=True, exist_ok=True)
 
                     if not skip_audio:
                         util.restore_audio(video_file_name, v, destination)

--- a/roop/core.py
+++ b/roop/core.py
@@ -314,7 +314,11 @@ def batch_process(files, use_clip, new_clip_text, use_new_method) -> None:
         if util.has_image_extension(fullname):
             imagefiles.append(fullname)
             destination = util.get_destfilename_from_path(fullname, roop.globals.output_path, f'.{roop.globals.CFG.output_image_format}')
-            imagefinalnames.append(util.replace_template(destination, index=index))
+            destination = util.replace_template(destination, index=index)
+
+            pathlib.Path(os.path.dirname(destination)).mkdir(parents=True, exist_ok=True)
+
+            imagefinalnames.append(destination)
         elif util.is_video(fullname) or util.has_extension(fullname, ['gif']):
             videofiles.append(fullname)
             destination = util.get_destfilename_from_path(fullname, roop.globals.output_path, f'__temp.{roop.globals.CFG.output_video_format}')

--- a/roop/template_parser.py
+++ b/roop/template_parser.py
@@ -1,0 +1,23 @@
+import re
+from datetime import datetime
+
+template_functions = {
+    "timestamp": lambda data: str(int(datetime.now().timestamp())),
+    "i": lambda data: data.get("index", False),
+    "file": lambda data: data.get("file", False),
+    "date": lambda data: datetime.now().strftime("%Y-%m-%d"),
+    "time": lambda data: datetime.now().strftime("%H-%M-%S"),
+}
+
+
+def parse(text: str, data: dict):
+    pattern = r"\{([^}]+)\}"
+
+    matches = re.findall(pattern, text)
+
+    for match in matches:
+        replacement = template_functions[match](data)
+        if replacement is not False:
+            text = text.replace(f"{{{match}}}", replacement)
+
+    return text

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -236,7 +236,7 @@ def run():
                     with gr.Column():
                         settings_controls.append(gr.Checkbox(label="Public Server", value=roop.globals.CFG.server_share, elem_id='server_share', interactive=True))
                         settings_controls.append(gr.Checkbox(label='Clear output folder before each run', value=roop.globals.CFG.clear_output, elem_id='clear_output', interactive=True))
-                        output_template = gr.Textbox(label="Output Template", lines=1, value=roop.globals.CFG.output_template)
+                        output_template = gr.Textbox(label="Output Template", info="(The file extension is added automatically)", lines=1, value=roop.globals.CFG.output_template)
                     with gr.Column():
                         input_server_name = gr.Textbox(label="Server Name", lines=1, info="Leave blank to run locally", value=roop.globals.CFG.server_name)
                     with gr.Column():

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -236,6 +236,7 @@ def run():
                     with gr.Column():
                         settings_controls.append(gr.Checkbox(label="Public Server", value=roop.globals.CFG.server_share, elem_id='server_share', interactive=True))
                         settings_controls.append(gr.Checkbox(label='Clear output folder before each run', value=roop.globals.CFG.clear_output, elem_id='clear_output', interactive=True))
+                        output_template = gr.Textbox(label="Output Template", lines=1, info="The output format supporting template replacement. The extension will be added automatically. {file}: The input filename; {dt} The current epoch timestamp", value=roop.globals.CFG.output_template)
                     with gr.Column():
                         input_server_name = gr.Textbox(label="Server Name", lines=1, info="Leave blank to run locally", value=roop.globals.CFG.server_name)
                     with gr.Column():
@@ -320,7 +321,7 @@ def run():
             video_quality.input(fn=lambda a,b='video_quality':on_settings_changed_misc(a,b), inputs=[video_quality])
 
             button_clean_temp.click(fn=clean_temp, outputs=[bt_srcimg, input_faces, target_faces, bt_destfiles])
-            button_apply_settings.click(apply_settings, inputs=[themes, input_server_name, input_server_port])
+            button_apply_settings.click(apply_settings, inputs=[themes, input_server_name, input_server_port, output_template])
             button_apply_restart.click(restart)
 
 
@@ -731,7 +732,7 @@ def on_join_videos(files):
     filenames = []
     for f in files:
         filenames.append(f.name)
-    destfile = util.get_destfilename_from_path(filenames[0], './output', '_join')        
+    destfile = util.get_destfilename_from_path(filenames[0], './output', '_join')
     util.join_videos(filenames, destfile)
     resultfiles = []
     if os.path.isfile(destfile):
@@ -786,10 +787,11 @@ def clean_temp():
     return None,None,None,None
 
 
-def apply_settings(themes, input_server_name, input_server_port):
+def apply_settings(themes, input_server_name, input_server_port, output_template):
     roop.globals.CFG.selected_theme = themes
     roop.globals.CFG.server_name = input_server_name
     roop.globals.CFG.server_port = input_server_port
+    roop.globals.CFG.output_template = output_template
     roop.globals.CFG.save()
     show_msg('Settings saved')
 

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -236,7 +236,22 @@ def run():
                     with gr.Column():
                         settings_controls.append(gr.Checkbox(label="Public Server", value=roop.globals.CFG.server_share, elem_id='server_share', interactive=True))
                         settings_controls.append(gr.Checkbox(label='Clear output folder before each run', value=roop.globals.CFG.clear_output, elem_id='clear_output', interactive=True))
-                        output_template = gr.Textbox(label="Output Template", lines=1, info="The output format supporting template replacement. The extension will be added automatically. {file}: The input filename; {dt} The current epoch timestamp", value=roop.globals.CFG.output_template)
+                        with gr.Group():
+                            gr.Markdown("""
+                                ## Output Template
+
+                                The output format supporting template replacement.  
+                                The extension will be added automatically.
+                            """)
+                            with gr.Accordion(label="Template Parameters", open=False):
+                                gr.Markdown("""
+                                    `{i}` The index of this file in the destination queue  
+                                    `{file}` The input filename without it's extension  
+                                    `{date}` The date in format YYYY-MM-DD (zero-padded)  
+                                    `{time}` The time in format HH-MM-SS (zero-padded)  
+                                    `{timestamp}` The current epoch timestamp
+                                """)
+                            output_template = gr.Textbox(show_label=False, lines=1, value=roop.globals.CFG.output_template)
                     with gr.Column():
                         input_server_name = gr.Textbox(label="Server Name", lines=1, info="Leave blank to run locally", value=roop.globals.CFG.server_name)
                     with gr.Column():

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -83,13 +83,6 @@ def run():
     run_server = True
     mycss = """
         span {color: var(--block-info-text-color)}
-        .markdown_group_fix .block {
-            background: var(--block-background-fill);
-            padding: 8px;
-        }
-        .markdown_group_fix h2 {
-            margin-top: 0 !important;
-        }
         #filelist {
             max-height: 238.4px;
             overflow-y: auto !important;
@@ -243,23 +236,7 @@ def run():
                     with gr.Column():
                         settings_controls.append(gr.Checkbox(label="Public Server", value=roop.globals.CFG.server_share, elem_id='server_share', interactive=True))
                         settings_controls.append(gr.Checkbox(label='Clear output folder before each run', value=roop.globals.CFG.clear_output, elem_id='clear_output', interactive=True))
-
-                        with gr.Group(elem_classes=["markdown_group_fix"]):
-                            gr.Markdown("""
-                                ## Output Template
-
-                                The output format supporting template replacement.  
-                                The file extension will be added automatically.
-                            """)
-                            with gr.Accordion(label="Template Parameters", open=False):
-                                gr.Markdown("""
-                                    `{i}` The index of this file in the destination queue  
-                                    `{file}` The input filename without it's extension  
-                                    `{date}` The date in format YYYY-MM-DD (zero-padded)  
-                                    `{time}` The time in format HH-MM-SS (zero-padded)  
-                                    `{timestamp}` The current epoch timestamp
-                                """)
-                            output_template = gr.Textbox(show_label=False, lines=1, value=roop.globals.CFG.output_template)
+                        output_template = gr.Textbox(label="Output Template", lines=1, value=roop.globals.CFG.output_template)
                     with gr.Column():
                         input_server_name = gr.Textbox(label="Server Name", lines=1, info="Leave blank to run locally", value=roop.globals.CFG.server_name)
                     with gr.Column():

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -83,6 +83,13 @@ def run():
     run_server = True
     mycss = """
         span {color: var(--block-info-text-color)}
+        .markdown_group_fix .block {
+            background: var(--block-background-fill);
+            padding: 8px;
+        }
+        .markdown_group_fix h2 {
+            margin-top: 0 !important;
+        }
         #filelist {
             max-height: 238.4px;
             overflow-y: auto !important;
@@ -236,12 +243,13 @@ def run():
                     with gr.Column():
                         settings_controls.append(gr.Checkbox(label="Public Server", value=roop.globals.CFG.server_share, elem_id='server_share', interactive=True))
                         settings_controls.append(gr.Checkbox(label='Clear output folder before each run', value=roop.globals.CFG.clear_output, elem_id='clear_output', interactive=True))
-                        with gr.Group():
+
+                        with gr.Group(elem_classes=["markdown_group_fix"]):
                             gr.Markdown("""
                                 ## Output Template
 
                                 The output format supporting template replacement.  
-                                The extension will be added automatically.
+                                The file extension will be added automatically.
                             """)
                             with gr.Accordion(label="Template Parameters", open=False):
                                 gr.Markdown("""

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -10,7 +10,8 @@ import urllib
 import torch
 import gradio
 import tempfile
-import time
+
+from datetime import datetime
 
 from pathlib import Path
 from typing import List, Any
@@ -122,19 +123,23 @@ def get_destfilename_from_path(srcfilepath: str, destfilepath: str, extension: s
         return os.path.join(destfilepath, f'{fn}{extension}')
     return os.path.join(destfilepath, f'{fn}{extension}{ext}')
 
-def replace_template(file_path: str):
+def replace_template(file_path: str, index: int = 0):
     fn, ext = os.path.splitext(os.path.basename(file_path))
-
+    
     # Remove the "__temp" placeholder that was used as a temporary filename
     fn = fn.replace('__temp', '')
+    now = datetime.now()
+    timestamp = int(now.timestamp())
 
-    current_dt = int(time.time())
     template = roop.globals.CFG.output_template
 
     # Replace placeholders with actual values
     replaced_filename = template \
         .replace("{file}", fn) \
-        .replace("{dt}", str(current_dt))
+        .replace("{i}", str(index)) \
+        .replace("{date}", now.strftime("%Y-%m-%d")) \
+        .replace("{time}", now.strftime("%H-%M-%S")) \
+        .replace("{timestamp}", str(timestamp))
 
     return os.path.join(roop.globals.output_path, f'{replaced_filename}{ext}')
 

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -121,7 +121,21 @@ def get_destfilename_from_path(srcfilepath: str, destfilepath: str, extension: s
         return os.path.join(destfilepath, f'{fn}{extension}')
     return os.path.join(destfilepath, f'{fn}{extension}{ext}')
 
+def replace_template(file_path: str):
+    fn, ext = os.path.splitext(os.path.basename(file_path))
 
+    # Remove the "__temp" placeholder that was used as a temporary filename
+    fn = fn.replace('__temp', '')
+
+    current_dt = int(time.time())
+    template = roop.globals.CFG.output_template
+
+    # Replace placeholders with actual values
+    replaced_filename = template \
+        .replace("{file}", fn) \
+        .replace("{dt}", str(current_dt))
+
+    return os.path.join(roop.globals.output_path, f'{replaced_filename}{ext}')
 
 
 def create_temp(target_path: str) -> None:

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -18,6 +18,8 @@ from typing import List, Any
 from tqdm import tqdm
 from scipy.spatial import distance
 
+import roop.template_parser as template_parser
+
 import roop.globals
 
 TEMP_FILE = 'temp.mp4'
@@ -128,18 +130,12 @@ def replace_template(file_path: str, index: int = 0):
     
     # Remove the "__temp" placeholder that was used as a temporary filename
     fn = fn.replace('__temp', '')
-    now = datetime.now()
-    timestamp = int(now.timestamp())
 
     template = roop.globals.CFG.output_template
-
-    # Replace placeholders with actual values
-    replaced_filename = template \
-        .replace("{file}", fn) \
-        .replace("{i}", str(index)) \
-        .replace("{date}", now.strftime("%Y-%m-%d")) \
-        .replace("{time}", now.strftime("%H-%M-%S")) \
-        .replace("{timestamp}", str(timestamp))
+    replaced_filename = template_parser.parse(template, {
+        'index': str(index),
+        'file': fn
+    })
 
     return os.path.join(roop.globals.output_path, f'{replaced_filename}{ext}')
 

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -10,6 +10,7 @@ import urllib
 import torch
 import gradio
 import tempfile
+import time
 
 from pathlib import Path
 from typing import List, Any
@@ -83,7 +84,7 @@ def create_gif_from_video(video_path: str, gif_path):
     fps = detect_fps(video_path)
     frame = get_video_frame(video_path)
 
-    run_ffmpeg(['-i', video_path, '-vf', f'fps={fps},scale={frame.shape[0]}:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse', '-loop', '0', gif_path])
+    run_ffmpeg(['-i', video_path, '-vf', f'fps={fps},scale={frame.shape[1]}:-1:flags=lanczos,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse', '-loop', '0', gif_path])
 
 
 def restore_audio(intermediate_video: str, original_video: str, final_video: str) -> None:

--- a/settings.py
+++ b/settings.py
@@ -36,6 +36,7 @@ class Settings:
         self.frame_buffer_size = self.default_get(data, 'frame_buffer_size', 4)
         self.provider = self.default_get(data, 'provider', 'cuda')
         self.force_cpu = self.default_get(data, 'force_cpu', False)
+        self.output_template = self.default_get(data, 'output_template', '{file}.fake.{dt}')
 
 
 
@@ -56,7 +57,8 @@ class Settings:
             'memory_limit' : self.memory_limit,
             'frame_buffer_size' : self.frame_buffer_size,
             'provider' : self.provider,
-            'force_cpu' : self.force_cpu
+            'force_cpu' : self.force_cpu,
+			'output_template' : self.output_template
         }
         with open(self.config_file, 'w') as f:
             yaml.dump(data, f)

--- a/settings.py
+++ b/settings.py
@@ -36,7 +36,7 @@ class Settings:
         self.frame_buffer_size = self.default_get(data, 'frame_buffer_size', 4)
         self.provider = self.default_get(data, 'provider', 'cuda')
         self.force_cpu = self.default_get(data, 'force_cpu', False)
-        self.output_template = self.default_get(data, 'output_template', '{file}.fake.{timestamp}')
+        self.output_template = self.default_get(data, 'output_template', '{date}/{i}.{time}.{file}')
 
 
 

--- a/settings.py
+++ b/settings.py
@@ -36,7 +36,7 @@ class Settings:
         self.frame_buffer_size = self.default_get(data, 'frame_buffer_size', 4)
         self.provider = self.default_get(data, 'provider', 'cuda')
         self.force_cpu = self.default_get(data, 'force_cpu', False)
-        self.output_template = self.default_get(data, 'output_template', '{file}.fake.{dt}')
+        self.output_template = self.default_get(data, 'output_template', '{file}.fake.{timestamp}')
 
 
 


### PR DESCRIPTION
Addresses #153 

Default is `{file}.fake.{dt}` - the extension is automatically added.
![image](https://github.com/C0untFloyd/roop-unleashed/assets/1345036/fc547814-c0db-4de2-a4a7-44f64bb27898)

Images will have their output be in the format that is set in the Settings tab (or the config file)

GIFs and videos will have their temporary files named purely based on the input filename and `__temp` as the suffix.
So as an example, a file called `cool_backflip.mp4` would be temporarily renamed to `cool_backflip__temp.mp4`.

Once processing is done and the video is being merged back into a video, it'll replace the filename with the template and fill in the information for it. It will also remove `__temp` from the filename.

I tried adding new-lines into the info for the textbox in the Settings tab, but I'm unsure how to do that with Gradio (if it even supports it).
Perhaps it's better to link to the README instead and add it into that?
___
Another issue I found which I added as a commit in this is that GIFs were converted with the wrong ratio.

The format that `get_video_frame` returns is `height, width`, whereas FFMPEG's `scale` argument uses `width:height`, so it was a simple fix (`frame.shape[1]` instead of `[0]`)