### PR TITLE
new "Rebuild video from existing frames" switch in GUI

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -22,6 +22,7 @@ import roop.metadata
 import roop.ui as ui
 from roop.processors.frame.core import get_frame_processors_modules
 from roop.utilities import has_image_extension, is_image, is_video, detect_fps, create_video, extract_frames, get_temp_frame_paths, restore_audio, create_temp, move_temp, clean_temp, normalize_output_path, has_extension
+from roop.utilities import get_temp_directory_path
 from roop.face_analyser import extract_face_images
 
 if 'ROCMExecutionProvider' in roop.globals.execution_providers:
@@ -187,20 +188,24 @@ def start() -> None:
             update_status('Processing to image failed!')
         return
 
-    update_status('Creating temp resources...')
-    create_temp(current_target)
-    update_status('Extracting frames...')
-    extract_frames(current_target)
-    temp_frame_paths = get_temp_frame_paths(current_target)
+    if roop.globals.rebuild_video==False:
+        update_status('Creating temp resources...')
+        create_temp(current_target)
+        update_status('Extracting frames...')
+        extract_frames(current_target)
+        temp_frame_paths = get_temp_frame_paths(current_target)
 
-    for frame_processor in get_frame_processors_modules(roop.globals.frame_processors):
-        if frame_processor.NAME == 'ROOP.FACE-ENHANCER' and roop.globals.selected_enhancer == 'None':
-            continue
+        for frame_processor in get_frame_processors_modules(roop.globals.frame_processors):
+            if frame_processor.NAME == 'ROOP.FACE-ENHANCER' and roop.globals.selected_enhancer == 'None':
+                continue
 
-        update_status(f'{frame_processor.NAME} in progress...')
-        frame_processor.process_video(roop.globals.SELECTED_FACE_DATA_INPUT, roop.globals.SELECTED_FACE_DATA_OUTPUT, temp_frame_paths)
-        frame_processor.post_process()
-        release_resources()
+            update_status(f'{frame_processor.NAME} in progress...')
+            frame_processor.process_video(roop.globals.SELECTED_FACE_DATA_INPUT, roop.globals.SELECTED_FACE_DATA_OUTPUT, temp_frame_paths)
+            frame_processor.post_process()
+            release_resources()
+    else:
+        print("rebuilding video from frames in:",get_temp_directory_path(current_target))
+
     # handles fps
     if roop.globals.keep_fps:
         update_status('Detecting fps...')

--- a/roop/globals.py
+++ b/roop/globals.py
@@ -10,6 +10,7 @@ keep_fps = None
 keep_frames = None
 skip_audio = None
 many_faces = None
+rebuild_video=False
 use_batch = None
 source_face_index = 0
 target_face_index = 0

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -94,6 +94,10 @@ def create_root(start: Callable, destroy: Callable) -> ctk.CTk:
     many_faces_switch = ctk.CTkSwitch(root, text='Many faces', variable=many_faces_value, command=lambda: setattr(roop.globals, 'many_faces', many_faces_value.get()))
     many_faces_switch.place(relx=base_x2, rely=0.68)
 
+    rebuild_video_value = ctk.BooleanVar(value=roop.globals.rebuild_video)
+    rebuild_video_switch = ctk.CTkSwitch(root, text='Rebuild video from existing frames', variable=rebuild_video_value, command=lambda: setattr(roop.globals, 'rebuild_video', rebuild_video_value.get()))
+    rebuild_video_switch.place(relx=base_x2, rely=0.725)
+
     use_batch_value = ctk.BooleanVar(value=roop.globals.use_batch)
     use_batch_switch = ctk.CTkSwitch(root, text='Batch process folder', variable=use_batch_value, command=lambda: setattr(roop.globals, 'use_batch', use_batch_value.get()))
     use_batch_switch.place(relx=base_x1, rely=0.725)


### PR DESCRIPTION
Add a "Rebuild video from existing frames" switch in the GUI for this usage scenario:

* You make a video with "Keep frames" switch on.
* You make changes to some (or all) PNG files in the frame directory.
* You turn on the "Rebuild video from existing frames" switch, and click "Start" button to make another video.
* The program will make a new video using existing frames, skipping the frame extraction and processing steps.
