### PR TITLE
TKInter branch: speed up video frame seeking in preview window

### DIFF
--- a/roop/capturer.py
+++ b/roop/capturer.py
@@ -20,3 +20,11 @@ def get_video_frame_total(video_path: str) -> int:
     video_frame_total = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
     capture.release()
     return video_frame_total
+
+def get_video_frame2(capture,frame_number: int = 0) -> Optional[Frame]:
+    frame_total = capture.get(cv2.CAP_PROP_FRAME_COUNT)
+    capture.set(cv2.CAP_PROP_POS_FRAMES, min(frame_total, frame_number - 1))
+    has_frame, frame = capture.read()
+    if has_frame:
+        return frame
+    return None


### PR DESCRIPTION
Store the opened OpenCV video handle in the preview window object. When the user move the preview video position slider, use the stored video handle to read frames instead of re-opening the video file every time. This greatly speeds up the preview update for some videos.