### PR TITLE
Tkinter: speed up preview video frame seeking and cleanup for lint check

### DIFF
--- a/roop/capturer.py
+++ b/roop/capturer.py
@@ -21,6 +21,7 @@ def get_video_frame_total(video_path: str) -> int:
     capture.release()
     return video_frame_total
 
+
 def get_video_frame2(capture,frame_number: int = 0) -> Optional[Frame]:
     frame_total = capture.get(cv2.CAP_PROP_FRAME_COUNT)
     capture.set(cv2.CAP_PROP_POS_FRAMES, min(frame_total, frame_number - 1))

--- a/roop/capturer.py
+++ b/roop/capturer.py
@@ -20,3 +20,11 @@ def get_video_frame_total(video_path: str) -> int:
     video_frame_total = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
     capture.release()
     return video_frame_total
+
+def get_video_frame2(capture,frame_number: int = 0) -> Optional[Frame]:
+    frame_total = capture.get(cv2.CAP_PROP_FRAME_COUNT)
+    capture.set(cv2.CAP_PROP_POS_FRAMES, min(frame_total, frame_number - 1))
+    has_frame, frame = capture.read()
+    if has_frame:
+        return frame
+    return None

--- a/roop/ui.py
+++ b/roop/ui.py
@@ -7,7 +7,7 @@ import roop.metadata
 from typing import Callable, Tuple
 from PIL import Image, ImageOps
 from roop.face_analyser import extract_face_images
-from roop.capturer import get_video_frame, get_video_frame2, get_video_frame_total
+from roop.capturer import get_video_frame2, get_video_frame_total
 from roop.processors.frame.core import get_frame_processors_modules
 from roop.utilities import is_image, is_video, resolve_relative_path, open_with_default_app, compute_cosine_distance, has_extension
 


### PR DESCRIPTION
Store the opened OpenCV video handle in the preview window object. When the user move the preview video position slider, use the stored video handle to read frames instead of re-opening the video file every time. This greatly speeds up the preview update for some videos.

Also cleanup of ui.py and capturer.py to pass github lint check.