### PR TITLE
Auto rotate frames containing faces that are not vertical to fix crappy insight face bug.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ temp
 config.yaml
 run.bat
 venv
+start.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ tqdm==4.66.1
 ftfy
 regex
 pyvirtualcam
+imutils==0.5.4

--- a/roop/ProcessMgr.py
+++ b/roop/ProcessMgr.py
@@ -392,12 +392,23 @@ class ProcessMgr():
         # then use that to determine which way the face is actually facing when in a horizontal position
         # and use that to determine the correct rotation_action
 
+        # print(original_face.landmark_2d_106)
+
+        forehead_x = original_face.landmark_2d_106[72][0]
+        chin_x = original_face.landmark_2d_106[0][0]
+
         if horizontal_face:
+            if chin_x < forehead_x:
+                # this is someone lying down with their face like this (:
+                return "rotate_anticlockwise"
+            elif forehead_x < chin_x:
+                # this is someone lying down with their face like this :)
+                return "rotate_clockwise"
             if bbox_center_x >= center_x:
-                #this is someone lying down with their face in the right hand side of the frame
+                # this is someone lying down with their face in the right hand side of the frame
                 return "rotate_anticlockwise"
             if bbox_center_x < center_x:
-                #this is someone lying down with their face in the left hand side of the frame
+                # this is someone lying down with their face in the left hand side of the frame
                 return "rotate_clockwise"
 
         return "noop"
@@ -433,13 +444,10 @@ class ProcessMgr():
 
     def auto_unrotate_frame(self, frame:Frame, rotation_action):
         if rotation_action == "rotate_anticlockwise":
-            print("frame was rotated anti-clockwise, rotating processed frame clockwise")
             return rotate_clockwise(frame)
         elif rotation_action == "rotate_clockwise":
-            print("frame was rotated clockwise, rotating processed frame anti-clockwise")
             return rotate_anticlockwise(frame)
         
-        print("face was vertical, leaving processed frame untouched")
         return frame
 
 
@@ -458,7 +466,6 @@ class ProcessMgr():
                 rotated_target_face = rotated_face
                 best_iou = iou
             
-        print(f"closest matching face - iou: {best_iou}, bbox: {rotated_target_face.bbox}, rotated bbox: {rotated_bbox}")
         return rotated_target_face
 
 

--- a/roop/ProcessMgr.py
+++ b/roop/ProcessMgr.py
@@ -422,17 +422,15 @@ class ProcessMgr():
         rotation_action = self.rotation_action(original_face, frame)
 
         if rotation_action == "rotate_anticlockwise":
-            #print("face is horizontal, rotating frame anti-clockwise and getting face bounding box from rotated frame")
+            #face is horizontal, rotating frame anti-clockwise and getting face bounding box from rotated frame
             rotated_bbox = self.rotate_bbox_anticlockwise(original_face.bbox, frame)
             frame = rotate_anticlockwise(frame)
             target_face = self.get_rotated_target_face(rotated_bbox, frame)
         elif rotation_action == "rotate_clockwise":
-            #print("face is horizontal, rotating frame clockwise and getting face bounding box from rotated frame")
+            #face is horizontal, rotating frame clockwise and getting face bounding box from rotated frame
             rotated_bbox = self.rotate_bbox_clockwise(original_face.bbox, frame)
             frame = rotate_clockwise(frame)
             target_face = self.get_rotated_target_face(rotated_bbox, frame)
-        else:
-            #print("face is vertical, leaving frame untouched")
 
         if target_face is None:
             #no face was detected in the rotated frame, so use the original frame and face

--- a/roop/ProcessMgr.py
+++ b/roop/ProcessMgr.py
@@ -259,6 +259,11 @@ class ProcessMgr():
             return faces, frame
         return None, frame
       
+# https://github.com/deepinsight/insightface#third-party-re-implementation-of-arcface
+# https://github.com/deepinsight/insightface/blob/master/alignment/coordinate_reg/image_infer.py
+# https://github.com/deepinsight/insightface/issues/1350
+# https://github.com/linghu8812/tensorrt_inference
+
 
     def process_frame(self, frame:Frame):
         use_original_frame = 0

--- a/roop/ProcessMgr.py
+++ b/roop/ProcessMgr.py
@@ -294,6 +294,7 @@ class ProcessMgr():
 
     def swap_faces(self, frame, temp_frame):
         num_faces_found = 0
+
         if self.options.swap_mode == "first":
             face = get_first_face(frame)
 
@@ -306,6 +307,13 @@ class ProcessMgr():
             faces = get_all_faces(frame)
             if faces is None:
                 return num_faces_found, frame
+
+            if self.options.swap_mode == "single_face_frames_only":
+                if len(faces) == 1:
+                    num_faces_found += 1
+                    temp_frame = self.process_face(self.options.selected_index, faces[0], temp_frame)
+                else:
+                    return num_faces_found, frame
             
             if self.options.swap_mode == "all":
                 for face in faces:

--- a/roop/ProcessMgr.py
+++ b/roop/ProcessMgr.py
@@ -349,12 +349,13 @@ class ProcessMgr():
         center_x = width // 2.0
         start_x = original_face.bbox[0]
         end_x = original_face.bbox[2]
+        bbox_center_x = start_x + (bounding_box_width // 2.0)
 
         if horizontal_face:
-            if start_x > center_x:
+            if bbox_center_x >= center_x:
                 #this is someone lying down with their face in the right hand side of the frame
                 return "rotate_anticlockwise"
-            if end_x < center_x:
+            if bbox_center_x < center_x:
                 #this is someone lying down with their face in the left hand side of the frame
                 return "rotate_clockwise"
 
@@ -404,7 +405,7 @@ class ProcessMgr():
     def get_rotated_target_face(self, rotated_bbox, rotated_frame:Frame):
         rotated_faces = get_all_faces(rotated_frame)
 
-        if rotated_faces is None:
+        if not rotated_faces:
             return None
 
         rotated_target_face = rotated_faces[0]

--- a/roop/ProcessMgr.py
+++ b/roop/ProcessMgr.py
@@ -281,10 +281,8 @@ class ProcessMgr():
         if roop.globals.no_face_action == skip_frame:
             #This only works with in-mem processing, as it simply skips the frame.
             #For 'extract frames' it simply leaves the unprocessed frame unprocessed and it gets used in the final output by ffmpeg.
-            #If we could delete that frame here, that'd work but that might fuck up ffmpeg, and I don't think we have the info on what frame it actually is?????
+            #If we could delete that frame here, that'd work but that might cause ffmpeg to fail unless the frames are renamed, and I don't think we have the info on what frame it actually is?????
             #alternatively, it could mark all the necessary frames for deletion, delete them at the end, then rename the remaining frames that might work?
-            #alternatively to that we just get this auto-rotation business working for in-mem processing, which would be ideal!
-            #fucking spaghetti code this is man... but even in all its noodleyness, boy is it good.
             return None
         else:
             copyframe = frame.copy()
@@ -397,8 +395,6 @@ class ProcessMgr():
         # then use that to determine which way the face is actually facing when in a horizontal position
         # and use that to determine the correct rotation_action
 
-        # print(original_face.landmark_2d_106)
-
         forehead_x = original_face.landmark_2d_106[72][0]
         chin_x = original_face.landmark_2d_106[0][0]
 
@@ -426,17 +422,17 @@ class ProcessMgr():
         rotation_action = self.rotation_action(original_face, frame)
 
         if rotation_action == "rotate_anticlockwise":
-            print("face is horizontal, rotating frame anti-clockwise and getting face bounding box from rotated frame")
+            #print("face is horizontal, rotating frame anti-clockwise and getting face bounding box from rotated frame")
             rotated_bbox = self.rotate_bbox_anticlockwise(original_face.bbox, frame)
             frame = rotate_anticlockwise(frame)
             target_face = self.get_rotated_target_face(rotated_bbox, frame)
         elif rotation_action == "rotate_clockwise":
-            print("face is horizontal, rotating frame clockwise and getting face bounding box from rotated frame")
+            #print("face is horizontal, rotating frame clockwise and getting face bounding box from rotated frame")
             rotated_bbox = self.rotate_bbox_clockwise(original_face.bbox, frame)
             frame = rotate_clockwise(frame)
             target_face = self.get_rotated_target_face(rotated_bbox, frame)
         else:
-            print("face is vertical, leaving frame untouched")
+            #print("face is vertical, leaving frame untouched")
 
         if target_face is None:
             #no face was detected in the rotated frame, so use the original frame and face

--- a/roop/core.py
+++ b/roop/core.py
@@ -291,7 +291,7 @@ def batch_process(files:list[ProcessEntry], use_clip, new_clip_text, use_new_met
                     print("Resorting frames to create video")
                     util.sort_rename_frames(extract_path)                                    
                 
-                ffmpeg.create_video(v.filename, f.finalname, fps)
+                ffmpeg.create_video(v.filename, v.finalname, fps)
                 if not roop.globals.keep_frames:
                     util.delete_temp_frames(temp_frame_paths[0])
             else:

--- a/roop/face_util.py
+++ b/roop/face_util.py
@@ -5,6 +5,7 @@ import insightface
 import roop.globals
 from roop.typing import Frame, Face
 
+import imutils
 import cv2
 import numpy as np
 from skimage import transform as trans
@@ -187,7 +188,16 @@ def rotate_image_90(image, rotate=True):
         return np.rot90(image)
     else:
         return np.rot90(image,1,(1,0))
-    
+
+
+def rotate_anticlockwise(frame):
+    return imutils.rotate_bound(frame, -90)
+
+
+def rotate_clockwise(frame):
+    return imutils.rotate_bound(frame, 90)
+
+
 def rotate_image_180(image):
     return np.flip(image,0)
 

--- a/roop/util_ffmpeg.py
+++ b/roop/util_ffmpeg.py
@@ -65,14 +65,14 @@ def extract_frames(target_path : str, trim_frame_start, trim_frame_end, fps : fl
     commands = ['-i', target_path, '-q:v', '1', '-pix_fmt', 'rgb24', ]
     if trim_frame_start is not None and trim_frame_end is not None:
         commands.extend([ '-vf', 'trim=start_frame=' + str(trim_frame_start) + ':end_frame=' + str(trim_frame_end) + ',fps=' + str(fps) ])
-    commands.extend(['-vsync', '0', os.path.join(temp_directory_path, '%04d.' + roop.globals.CFG.output_image_format)])
+    commands.extend(['-vsync', '0', os.path.join(temp_directory_path, '%06d.' + roop.globals.CFG.output_image_format)])
     return run_ffmpeg(commands)
 
 
 def create_video(target_path: str, dest_filename: str, fps: float = 24.0, temp_directory_path: str = None) -> None:
     if temp_directory_path is None:
         temp_directory_path = util.get_temp_directory_path(target_path)
-    run_ffmpeg(['-r', str(fps), '-i', os.path.join(temp_directory_path, f'%04d.{roop.globals.CFG.output_image_format}'), '-c:v', roop.globals.video_encoder, '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-vf', 'colorspace=bt709:iall=bt601-6-625:fast=1', '-y', dest_filename])
+    run_ffmpeg(['-r', str(fps), '-i', os.path.join(temp_directory_path, f'%06d.{roop.globals.CFG.output_image_format}'), '-c:v', roop.globals.video_encoder, '-crf', str(roop.globals.video_quality), '-pix_fmt', 'yuv420p', '-vf', 'colorspace=bt709:iall=bt601-6-625:fast=1', '-y', dest_filename])
     return dest_filename
 
 

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -12,6 +12,7 @@ import gradio
 import tempfile
 import cv2
 import zipfile
+import traceback
 
 from pathlib import Path
 from typing import List, Any
@@ -278,9 +279,9 @@ def open_folder(path:str):
         elif platform == 'wsl':
             subprocess.call('cmd.exe /C start'.split() + [path])
         else:                                   # linux variants
-            subprocess.call('xdg-open', path)
+            subprocess.Popen(['xdg-open', path])
     except Exception as e:
-        print(e)
+        traceback.print_exc()
         pass
         #import webbrowser
         #webbrowser.open(url)

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -265,8 +265,8 @@ def unzip(zipfilename:str, target_path:str):
 
 
 def mkdir_with_umask(directory):
-    oldmask = os.umask(000)
-    os.makedirs(directory, mode=777, exist_ok=True)
+    oldmask = os.umask(0)
+    os.makedirs(directory, mode=0o775, exist_ok=True)
     os.umask(oldmask)
 
 def open_folder(path:str):

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -71,7 +71,7 @@ def sort_rename_frames(path: str):
     for i in range(len(filenames)):
         of = os.path.join(path, filenames[i])
         newidx = i+1
-        new_filename = os.path.join(path, f"{newidx:04d}." + roop.globals.CFG.output_image_format)
+        new_filename = os.path.join(path, f"{newidx:06d}." + roop.globals.CFG.output_image_format)
         os.rename(of, new_filename)        
 
 

--- a/ui/tabs/faceswap_tab.py
+++ b/ui/tabs/faceswap_tab.py
@@ -93,7 +93,7 @@ def faceswap_tab():
                     roop.globals.wait_after_extraction = gr.Checkbox(label="Wait for user key press before creating video ", value=False)
             with gr.Column(scale=1):
                 chk_useclip = gr.Checkbox(label="Use Text Masking", value=False)
-                clip_text = gr.Textbox(label="List of objects to mask and restore back on fake image", value="hand,penis" ,elem_id='tooltip')
+                clip_text = gr.Textbox(label="List of objects to mask and restore back on fake image", value="hand,penis,penis hole,tongue" ,elem_id='tooltip')
                 gr.Dropdown(["Clip2Seg"], value="Clip2Seg", label="Engine")
                 bt_preview_mask = gr.Button("👥 Show Mask Preview", variant='secondary')
                     

--- a/ui/tabs/faceswap_tab.py
+++ b/ui/tabs/faceswap_tab.py
@@ -80,20 +80,20 @@ def faceswap_tab():
     
         with gr.Row(variant='panel'):
             with gr.Column(scale=1):
-                selected_face_detection = gr.Dropdown(["First found", "Single face frames only", "All faces", "Selected face", "All female", "All male"], value="Single face frames only", label="Select face selection for swapping")
+                selected_face_detection = gr.Dropdown(["First found", "Single face frames only [auto-rotate]", "All faces", "Selected face", "All female", "All male"], value="First found", label="Select face selection for swapping")
                 max_face_distance = gr.Slider(0.01, 1.0, value=0.65, label="Max Face Similarity Threshold")
                 video_swapping_method = gr.Dropdown(["Extract Frames to media","In-Memory processing"], value="In-Memory processing", label="Select video processing method", interactive=True)
-                no_face_action = gr.Dropdown(choices=no_face_choices, value=no_face_choices[2], label="Action on no face detected", interactive=True)
+                no_face_action = gr.Dropdown(choices=no_face_choices, value=no_face_choices[0], label="Action on no face detected", interactive=True)
             with gr.Column(scale=1):
-                ui.globals.ui_selected_enhancer = gr.Dropdown(["None", "Codeformer", "DMDNet", "GFPGAN", "GPEN"], value="GPEN", label="Select post-processing")
-                ui.globals.ui_blend_ratio = gr.Slider(0.0, 1.0, value=0.7, label="Original/Enhanced image blend ratio")
+                ui.globals.ui_selected_enhancer = gr.Dropdown(["None", "Codeformer", "DMDNet", "GFPGAN", "GPEN"], value="None", label="Select post-processing")
+                ui.globals.ui_blend_ratio = gr.Slider(0.0, 1.0, value=0.65, label="Original/Enhanced image blend ratio")
                 with gr.Box():
                     roop.globals.skip_audio = gr.Checkbox(label="Skip audio", value=False)
                     roop.globals.keep_frames = gr.Checkbox(label="Keep Frames (relevant only when extracting frames)", value=False)
                     roop.globals.wait_after_extraction = gr.Checkbox(label="Wait for user key press before creating video ", value=False)
             with gr.Column(scale=1):
                 chk_useclip = gr.Checkbox(label="Use Text Masking", value=False)
-                clip_text = gr.Textbox(label="List of objects to mask and restore back on fake image", value="hand,penis,penis hole,tongue" ,elem_id='tooltip')
+                clip_text = gr.Textbox(label="List of objects to mask and restore back on fake image", value="cup,hands,hair,banana" ,elem_id='tooltip')
                 gr.Dropdown(["Clip2Seg"], value="Clip2Seg", label="Engine")
                 bt_preview_mask = gr.Button("👥 Show Mask Preview", variant='secondary')
                     
@@ -453,7 +453,7 @@ def translate_swap_mode(dropdown_text):
         return "selected"
     elif dropdown_text == "First found":
         return "first"
-    elif dropdown_text == "Single face frames only":
+    elif dropdown_text == "Single face frames only [auto-rotate]":
         return "single_face_frames_only"
     elif dropdown_text == "All female":
         return "all_female"

--- a/ui/tabs/faceswap_tab.py
+++ b/ui/tabs/faceswap_tab.py
@@ -80,20 +80,20 @@ def faceswap_tab():
     
         with gr.Row(variant='panel'):
             with gr.Column(scale=1):
-                selected_face_detection = gr.Dropdown(["First found", "Single face frames only", "All faces", "Selected face", "All female", "All male"], value="First found", label="Select face selection for swapping")
+                selected_face_detection = gr.Dropdown(["First found", "Single face frames only", "All faces", "Selected face", "All female", "All male"], value="Single face frames only", label="Select face selection for swapping")
                 max_face_distance = gr.Slider(0.01, 1.0, value=0.65, label="Max Face Similarity Threshold")
                 video_swapping_method = gr.Dropdown(["Extract Frames to media","In-Memory processing"], value="In-Memory processing", label="Select video processing method", interactive=True)
-                no_face_action = gr.Dropdown(choices=no_face_choices, value=no_face_choices[0], label="Action on no face detected", interactive=True)
+                no_face_action = gr.Dropdown(choices=no_face_choices, value=no_face_choices[2], label="Action on no face detected", interactive=True)
             with gr.Column(scale=1):
-                ui.globals.ui_selected_enhancer = gr.Dropdown(["None", "Codeformer", "DMDNet", "GFPGAN", "GPEN"], value="None", label="Select post-processing")
-                ui.globals.ui_blend_ratio = gr.Slider(0.0, 1.0, value=0.65, label="Original/Enhanced image blend ratio")
+                ui.globals.ui_selected_enhancer = gr.Dropdown(["None", "Codeformer", "DMDNet", "GFPGAN", "GPEN"], value="GPEN", label="Select post-processing")
+                ui.globals.ui_blend_ratio = gr.Slider(0.0, 1.0, value=0.7, label="Original/Enhanced image blend ratio")
                 with gr.Box():
                     roop.globals.skip_audio = gr.Checkbox(label="Skip audio", value=False)
                     roop.globals.keep_frames = gr.Checkbox(label="Keep Frames (relevant only when extracting frames)", value=False)
                     roop.globals.wait_after_extraction = gr.Checkbox(label="Wait for user key press before creating video ", value=False)
             with gr.Column(scale=1):
                 chk_useclip = gr.Checkbox(label="Use Text Masking", value=False)
-                clip_text = gr.Textbox(label="List of objects to mask and restore back on fake image", placeholder="cup,hands,hair,banana" ,elem_id='tooltip')
+                clip_text = gr.Textbox(label="List of objects to mask and restore back on fake image", value="hand,penis" ,elem_id='tooltip')
                 gr.Dropdown(["Clip2Seg"], value="Clip2Seg", label="Engine")
                 bt_preview_mask = gr.Button("👥 Show Mask Preview", variant='secondary')
                     

--- a/ui/tabs/faceswap_tab.py
+++ b/ui/tabs/faceswap_tab.py
@@ -80,7 +80,7 @@ def faceswap_tab():
     
         with gr.Row(variant='panel'):
             with gr.Column(scale=1):
-                selected_face_detection = gr.Dropdown(["First found", "All faces", "Selected face", "All female", "All male"], value="First found", label="Select face selection for swapping")
+                selected_face_detection = gr.Dropdown(["First found", "Single face frames only", "All faces", "Selected face", "All female", "All male"], value="First found", label="Select face selection for swapping")
                 max_face_distance = gr.Slider(0.01, 1.0, value=0.65, label="Max Face Similarity Threshold")
                 video_swapping_method = gr.Dropdown(["Extract Frames to media","In-Memory processing"], value="In-Memory processing", label="Select video processing method", interactive=True)
                 no_face_action = gr.Dropdown(choices=no_face_choices, value=no_face_choices[0], label="Action on no face detected", interactive=True)
@@ -453,6 +453,8 @@ def translate_swap_mode(dropdown_text):
         return "selected"
     elif dropdown_text == "First found":
         return "first"
+    elif dropdown_text == "Single face frames only":
+        return "single_face_frames_only"
     elif dropdown_text == "All female":
         return "all_female"
     elif dropdown_text == "All male":

--- a/ui/tabs/faceswap_tab.py
+++ b/ui/tabs/faceswap_tab.py
@@ -142,7 +142,7 @@ def faceswap_tab():
     bt_preview_mask.click(fn=on_preview_mask, inputs=[preview_frame_num, bt_destfiles, clip_text], outputs=[previewimage]) 
 
     start_event = bt_start.click(fn=start_swap, 
-        inputs=[ui.globals.ui_selected_enhancer, selected_face_detection, roop.globals.keep_frames,
+        inputs=[ui.globals.ui_selected_enhancer, selected_face_detection, roop.globals.keep_frames, roop.globals.wait_after_extraction,
                     roop.globals.skip_audio, max_face_distance, ui.globals.ui_blend_ratio, chk_useclip, clip_text,video_swapping_method, no_face_action],
         outputs=[bt_start, resultfiles])
     after_swap_event = start_event.then(fn=on_resultfiles_finished, inputs=[resultfiles], outputs=[resultimage, resultvideo])
@@ -462,7 +462,7 @@ def translate_swap_mode(dropdown_text):
 
 
 
-def start_swap( enhancer, detection, keep_frames, skip_audio, face_distance, blend_ratio,
+def start_swap( enhancer, detection, keep_frames, wait_after_extraction, skip_audio, face_distance, blend_ratio,
                 use_clip, clip_text, processing_method, no_face_action, progress=gr.Progress(track_tqdm=False)):
     from ui.main import prepare_environment
     from roop.core import batch_process
@@ -482,6 +482,7 @@ def start_swap( enhancer, detection, keep_frames, skip_audio, face_distance, ble
     roop.globals.distance_threshold = face_distance
     roop.globals.blend_ratio = blend_ratio
     roop.globals.keep_frames = keep_frames
+    roop.globals.wait_after_extraction = wait_after_extraction
     roop.globals.skip_audio = skip_audio
     roop.globals.face_swap_mode = translate_swap_mode(detection)
     roop.globals.no_face_action = index_of_no_face_action(no_face_action)


### PR DESCRIPTION
This PR is kind of huge and contains both a big feature upgrade and several major bug fixes. I'm not planning on making any major changes to this PR in order to help get it merged, so it will just be as-is, but I did still want to share the code in the hopes it helps the roop community move forward from this stupid bug in insight face that can't deal properly with faces that don't appear vertically in frames.

I developed this weeks ago, and from memory the several bug fixes also in it include:
- some permissions issue in Linux that was preventing me from creating facesets
- the 'open image folder' being broken on Linux
- not being able to process videos longer than 9999 frames
- some video file not saving due to wrong variable being used

**The feature: Auto-rotating frames containing faces that are not vertical**

The feature upgrade itself is auto rotating frames that contain a face that is not vertically oriented in order to make it vertically oriented during the faceswap, and then rotating it back to its original position afterwards. Normally, if you try to perform a faceswap with the insight face model on a video that has faces in a scene where someone is lying down or doing a confused dog pose with their head tilted sideways, then the face swap fails and generates horrible garbled results.

**The options you need to select to use this feature**:
- Select face selection for swapping -> Single face frames only [auto-rotate]
- Select video processing method -> In-Memory Processing
- Action on no face detected -> Skip Frame

**How the bug in insight face works**

How the bug works is that the insight face model returns the correct location for the bounding box of the face, but it tends to really screw up the position of the 2d landmarks in the face, and this is why the faceswap goes horribly wrong and becomes garbled. A number of users in the community have naturally happened upon the solution of simply rotating the video first before rooping it, and then rotating it back once it has been rooped. This works, but is a giant pain in the ass to prepare in cases where such a scene occurs part way through a video. Hence, I had a look to see if this process could be automated, and to my astonishment it actually can.

**How the algorithm to fix it works**:
- You work out if the face in the frame is horizontal (or thereabouts) by checking if the bounding box is wider than it is tall. 
- Then you need to leverage the positions of the 2d landmarks of the forehead and the chin to check which way the face is oriented in order to determine if you need to rotate the frame clockwise or anti-clockwise. 
- Then you need to translate the position of the bounding box to where you think the new bounding box will be once the frame has been rotated. 
- Then you need to detect all faces in the rotated frame, and to figure out which is the face you're intending to swap you compare the intersection over union between the translated bounding box (your estimate of where the face in the rotate frame will appear) and the bounding boxes of all the detected faces and the one with the smallest IOU is the one you're trying to swap. 
- Now that you have a reference to the face in the rotated frame you can do the faceswap, and once you're done you just unrotate the frame. 

**Notes**

The works almost perfectly with a few caveats, and could almost certainly be furthered improved, I just didn't care to at the time. The caveats are that it sometimes fails to detect the face in a frame, which results in the face flickering back and forth in the final video sometimes. The results I got were pretty usable, but to make them basically perfect by default what I did was just select the frame to skip frames where no face was detected. This works near perfectly, but results in some video artifacts where the video looks a little bit choppy in parts, and of course it won't contain any frames that don't contain a faces, which may be undesirable, but that's just the trade-off at this point. 

I'm sure this can be vastly improved to get near perfect results on basically any video without having to do any work to prepare the video in any way shape or form. I don't really like working in Python and find untested, dynamically typed codebases frustrating in general, and the structure of this codebase isn't well factored enough to easily make the subsequent changes needed to really take it to the next level, so I kind of ran out of patience with it and put it down at "good enough", but It could be improved to the point where the problem is basically completely solved.

**Some ideas to push this much further**:

There are basically two sub-problems remaining to solve here. 

- The first is that the model sometimes fails to detect a face in the rotated frame, despite one actually existing, and this leads to situations where 99.9% of the frames are processed correctly, but you get a little bit of flickering. 
- The second is that whilst skipping these frames generally (though not always) results in smooth looking video the downside is that it means you're also forced to skip all the frames that genuinely don't contain a face in them, which is sub-optimal.

I think to solve these problems you probably need to do something like shifting away from attempting to process each frame in isolation, but actually keep track of what processing actions took place on what frames, and do a second pass at the end where you apply some heuristics to look for cases where the model has likely made a mistake. For example, for each frame that was skipped check if the frames before and after contained a face that was rotated and swapped, and if they did then assume it was skipped by mistake and instead interpolate the missing frames. 

In theory if you develop a reliable algorithm to detect and fix this bug in insight face then that would allow you to build a pipeline that builds a dataset that could be used to train a model that augments insightface and fixes this problem without requiring all the code here. 

Further to that, if someone takes this and turns it into a ComfyUI node, and that allows us to build a workflow with it where we can feed it a video, have that video rooped reliably, then apply an img2img pass using a LoRA of our rooped subject to greatly enhance the quality of the face, then we could theoretically pump massive volumes of videos through that to build a dataset to train a better model which can do high resolution faceswaps. Probably anyway, right? I'm not a machine learning engineer, but it appears that's how this sort of thing works. 
