### PR TITLE
Moved face-analysis models location to ./models

### DIFF
--- a/roop/face_util.py
+++ b/roop/face_util.py
@@ -22,14 +22,15 @@ def get_face_analyser() -> Any:
 
     with THREAD_LOCK_ANALYSER:
         if FACE_ANALYSER is None:
+            model_path = resolve_relative_path('..')
             if roop.globals.CFG.force_cpu:
                 print("Forcing CPU for Face Analysis")
                 FACE_ANALYSER = insightface.app.FaceAnalysis(
-                    name="buffalo_l", providers=["CPUExecutionProvider"]
+                    name="buffalo_l", root=model_path, providers=["CPUExecutionProvider"]
                 )
             else:
                 FACE_ANALYSER = insightface.app.FaceAnalysis(
-                    name="buffalo_l", providers=roop.globals.execution_providers
+                    name="buffalo_l", root=model_path, providers=roop.globals.execution_providers
                 )
             FACE_ANALYSER.prepare(
                 ctx_id=0,


### PR DESCRIPTION
By default insightface face-analysis models like "buffalo_l" will always get downloaded to:

for Linux/Mac/Unix: **~/.insightface**
for Windows: **%userprofile%\\.insightface**

as it creates a sub folder named "buffalo_l" puts *.onnx models inside that folder.

This fix will download those face analysis models to ./models folder just like "inswapper" or any other models like this:

..\roop-unleashed\models\\**buffalo_l**
..\roop-unleashed\models\buffalo_l\\**1k3d68.onnx**
..\roop-unleashed\models\buffalo_l\\**2d106det.onnx**
..\roop-unleashed\models\buffalo_l\\**det_10g.onnx**
..\roop-unleashed\models\buffalo_l\\**genderage.onnx**
..\roop-unleashed\models\buffalo_l\\**w600k_r50.onnx**
