### PR TITLE
the batch process was always using options with an index 0 passed int…

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -211,7 +211,7 @@ def preview_mask(frame, clip_text):
 
 
 
-def batch_process(files:list[ProcessEntry], use_clip, new_clip_text, use_new_method, progress) -> None:
+def batch_process(files:list[ProcessEntry], use_clip, new_clip_text, use_new_method, progress, selected_index = 0) -> None:
     global clip_text, process_mgr
 
     roop.globals.processing = True
@@ -247,7 +247,7 @@ def batch_process(files:list[ProcessEntry], use_clip, new_clip_text, use_new_met
     if process_mgr is None:
         process_mgr = ProcessMgr(progress)
     
-    options = ProcessOptions(get_processing_plugins(use_clip), roop.globals.distance_threshold, roop.globals.blend_ratio, roop.globals.face_swap_mode, 0, new_clip_text)
+    options = ProcessOptions(get_processing_plugins(use_clip), roop.globals.distance_threshold, roop.globals.blend_ratio, roop.globals.face_swap_mode, selected_index, new_clip_text)
     process_mgr.initialize(roop.globals.INPUT_FACESETS, roop.globals.TARGET_FACES, options)
 
     if(len(imagefiles) > 0):

--- a/ui/tabs/faceswap_tab.py
+++ b/ui/tabs/faceswap_tab.py
@@ -509,7 +509,7 @@ def start_swap( enhancer, detection, keep_frames, wait_after_extraction, skip_au
     roop.globals.video_quality = roop.globals.CFG.video_quality
     roop.globals.max_memory = roop.globals.CFG.memory_limit if roop.globals.CFG.memory_limit > 0 else None
 
-    batch_process(list_files_process, use_clip, clip_text, processing_method == "In-Memory processing", progress)
+    batch_process(list_files_process, use_clip, clip_text, processing_method == "In-Memory processing", progress, SELECTED_INPUT_FACE_INDEX)
     is_processing = False
     outdir = pathlib.Path(roop.globals.output_path)
     outfiles = [item for item in outdir.rglob("*") if item.is_file()]


### PR DESCRIPTION
…o the process_mgr.initialize. This caused an issue when a user has multiple facesets loaded, it would always use the faceset at index 0 as the input for the swap even if a different faceset was selected. Changed it to use the SELECTED_INPUT_FACE_INDEX so now you could load more than one faceset and the swap will use the correct selected input face in the real swap.