### PR TITLE
User Configurable Models Directory

### DIFF
--- a/roop/core.py
+++ b/roop/core.py
@@ -115,21 +115,25 @@ def pre_check() -> bool:
     if sys.version_info < (3, 9):
         update_status('Python version is not supported - please upgrade to 3.9 or higher.')
         return False
-    
-    download_directory_path = util.resolve_relative_path('../models')
+
+    if not shutil.which('ffmpeg'):
+       update_status('ffmpeg is not installed.')
+    return True
+
+
+def download_initial_models() -> None:
+    download_directory_path = roop.globals.CFG.models_directory
+    print('using folder', download_directory_path)
     util.conditional_download(download_directory_path, ['https://huggingface.co/countfloyd/deepfake/resolve/main/inswapper_128.onnx'])
     util.conditional_download(download_directory_path, ['https://huggingface.co/countfloyd/deepfake/resolve/main/GFPGANv1.4.onnx'])
     util.conditional_download(download_directory_path, ['https://github.com/csxmli2016/DMDNet/releases/download/v1/DMDNet.pth'])
     util.conditional_download(download_directory_path, ['https://huggingface.co/countfloyd/deepfake/resolve/main/GPEN-BFR-512.onnx'])
     util.conditional_download(download_directory_path, ['https://huggingface.co/countfloyd/deepfake/resolve/main/restoreformer_plus_plus.onnx'])
-    download_directory_path = util.resolve_relative_path('../models/CLIP')
-    util.conditional_download(download_directory_path, ['https://huggingface.co/countfloyd/deepfake/resolve/main/rd64-uni-refined.pth'])
-    download_directory_path = util.resolve_relative_path('../models/CodeFormer')
-    util.conditional_download(download_directory_path, ['https://huggingface.co/countfloyd/deepfake/resolve/main/CodeFormerv0.1.onnx'])
 
-    if not shutil.which('ffmpeg'):
-       update_status('ffmpeg is not installed.')
-    return True
+    util.conditional_download(os.path.join(download_directory_path, 'CLIP'), ['https://huggingface.co/countfloyd/deepfake/resolve/main/rd64-uni-refined.pth'])
+
+    util.conditional_download(os.path.join(download_directory_path, 'CodeFormer'), ['https://huggingface.co/countfloyd/deepfake/resolve/main/CodeFormerv0.1.onnx'])
+
 
 def set_display_ui(function):
     global call_display_ui
@@ -364,4 +368,5 @@ def run() -> None:
     roop.globals.video_encoder = roop.globals.CFG.output_video_codec
     roop.globals.video_quality = roop.globals.CFG.video_quality
     roop.globals.max_memory = roop.globals.CFG.memory_limit if roop.globals.CFG.memory_limit > 0 else None
+    download_initial_models()
     main.run()

--- a/roop/core.py
+++ b/roop/core.py
@@ -123,7 +123,6 @@ def pre_check() -> bool:
 
 def download_initial_models() -> None:
     download_directory_path = roop.globals.CFG.models_directory
-    print('using folder', download_directory_path)
     util.conditional_download(download_directory_path, ['https://huggingface.co/countfloyd/deepfake/resolve/main/inswapper_128.onnx'])
     util.conditional_download(download_directory_path, ['https://huggingface.co/countfloyd/deepfake/resolve/main/GFPGANv1.4.onnx'])
     util.conditional_download(download_directory_path, ['https://github.com/csxmli2016/DMDNet/releases/download/v1/DMDNet.pth'])

--- a/roop/face_util.py
+++ b/roop/face_util.py
@@ -1,6 +1,7 @@
 import threading
 from typing import Any
 import insightface
+import os
 
 import roop.globals
 from roop.typing import Frame, Face
@@ -144,7 +145,7 @@ def get_face_swapper() -> Any:
 
     with THREAD_LOCK_SWAPPER:
         if FACE_SWAPPER is None:
-            model_path = resolve_relative_path("../models/inswapper_128.onnx")
+            model_path = os.path.join(roop.globals.CFG.models_directory, "inswapper_128.onnx")
             FACE_SWAPPER = insightface.model_zoo.get_model(
                 model_path, providers=roop.globals.execution_providers
             )
@@ -152,7 +153,7 @@ def get_face_swapper() -> Any:
 
 
 def pre_check() -> bool:
-    download_directory_path = resolve_relative_path("../models")
+    download_directory_path = roop.globals.CFG.models_directory
     conditional_download(
         download_directory_path,
         ["https://huggingface.co/countfloyd/deepfake/resolve/main/inswapper_128.onnx"],

--- a/roop/processors/Enhance_CodeFormer.py
+++ b/roop/processors/Enhance_CodeFormer.py
@@ -4,6 +4,7 @@ import threading
 import numpy as np
 import onnxruntime
 import onnx
+import os
 import roop.globals
 
 from roop.typing import Face, Frame, FaceSet
@@ -26,7 +27,7 @@ class Enhance_CodeFormer():
             # replace Mac mps with cpu for the moment
             devicename = devicename.replace('mps', 'cpu')
             self.devicename = devicename
-            model_path = resolve_relative_path('../models/CodeFormer/CodeFormerv0.1.onnx')
+            model_path = os.path.join(roop.globals.CFG.models_directory, 'CodeFormer/CodeFormerv0.1.onnx')
             self.model_codeformer = onnxruntime.InferenceSession(model_path, None, providers=roop.globals.execution_providers)
             self.model_inputs = self.model_codeformer.get_inputs()
             model_outputs = self.model_codeformer.get_outputs()

--- a/roop/processors/Enhance_DMDNet.py
+++ b/roop/processors/Enhance_DMDNet.py
@@ -1,6 +1,8 @@
 from typing import Any, List, Callable
 import cv2 
 import numpy as np
+import os
+import roop.globals
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -194,7 +196,7 @@ class Enhance_DMDNet():
     def create(self, devicename):
         self.torchdevice = torch.device(devicename)
         model_dmdnet = DMDNet().to(self.torchdevice)
-        weights = torch.load('./models/DMDNet.pth') 
+        weights = torch.load(os.path.join(roop.globals.CFG.models_directory, 'DMDNet.pth'))
         model_dmdnet.load_state_dict(weights, strict=True)
 
         model_dmdnet.eval()

--- a/roop/processors/Enhance_GFPGAN.py
+++ b/roop/processors/Enhance_GFPGAN.py
@@ -2,6 +2,7 @@ from typing import Any, List, Callable
 import cv2 
 import numpy as np
 import onnxruntime
+import os
 import roop.globals
 
 from roop.typing import Face, Frame, FaceSet
@@ -23,7 +24,7 @@ class Enhance_GFPGAN():
 
     def Initialize(self, devicename):
         if self.model_gfpgan is None:
-            model_path = resolve_relative_path('../models/GFPGANv1.4.onnx')
+            model_path = os.path.join(roop.globals.CFG.models_directory, 'GFPGANv1.4.onnx')
             self.model_gfpgan = onnxruntime.InferenceSession(model_path, None, providers=roop.globals.execution_providers)
             # replace Mac mps with cpu for the moment
             devicename = devicename.replace('mps', 'cpu')

--- a/roop/processors/Enhance_GPEN.py
+++ b/roop/processors/Enhance_GPEN.py
@@ -2,6 +2,7 @@ from typing import Any, List, Callable
 import cv2 
 import numpy as np
 import onnxruntime
+import os
 import roop.globals
 
 from roop.typing import Face, Frame, FaceSet
@@ -20,7 +21,7 @@ class Enhance_GPEN():
 
     def Initialize(self, devicename):
         if self.model_gpen is None:
-            model_path = resolve_relative_path('../models/GPEN-BFR-512.onnx')
+            model_path = os.path.join(roop.globals.CFG.models_directory, 'GPEN-BFR-512.onnx')
             self.model_gpen = onnxruntime.InferenceSession(model_path, None, providers=roop.globals.execution_providers)
             # replace Mac mps with cpu for the moment
             devicename = devicename.replace('mps', 'cpu')

--- a/roop/processors/Enhance_RestoreFormerPPlus.py
+++ b/roop/processors/Enhance_RestoreFormerPPlus.py
@@ -2,6 +2,7 @@ from typing import Any, List, Callable
 import cv2 
 import numpy as np
 import onnxruntime
+import os
 import roop.globals
 
 from roop.typing import Face, Frame, FaceSet
@@ -21,7 +22,7 @@ class Enhance_RestoreFormerPPlus():
             # replace Mac mps with cpu for the moment
             devicename = devicename.replace('mps', 'cpu')
             self.devicename = devicename
-            model_path = resolve_relative_path('../models/restoreformer_plus_plus.onnx')
+            model_path = os.path.join(roop.globals.CFG.models_directory, 'restoreformer_plus_plus.onnx')
             self.model_restoreformerpplus = onnxruntime.InferenceSession(model_path, None, providers=roop.globals.execution_providers)
             self.model_inputs = self.model_restoreformerpplus.get_inputs()
             model_outputs = self.model_restoreformerpplus.get_outputs()

--- a/roop/processors/FaceSwapInsightFace.py
+++ b/roop/processors/FaceSwapInsightFace.py
@@ -3,6 +3,7 @@ import roop.globals
 import insightface
 import cv2
 import numpy as np
+import os
 
 from roop.typing import Face, Frame
 from roop.utilities import resolve_relative_path
@@ -19,7 +20,7 @@ class FaceSwapInsightFace():
 
     def Initialize(self, devicename):
         if self.model_swap_insightface is None:
-            model_path = resolve_relative_path('../models/inswapper_128.onnx')
+            model_path = os.path.join(roop.globals.CFG.models_directory, 'inswapper_128.onnx')
             self.model_swap_insightface = insightface.model_zoo.get_model(model_path, providers=roop.globals.execution_providers)
 
     

--- a/roop/processors/Mask_Clip2Seg.py
+++ b/roop/processors/Mask_Clip2Seg.py
@@ -6,6 +6,7 @@ import threading
 from torchvision import transforms
 from clip.clipseg import CLIPDensePredT
 import numpy as np
+import roop.globals
 
 from roop.typing import Frame
 
@@ -24,7 +25,7 @@ class Mask_Clip2Seg():
         if self.model_clip is None:
             self.model_clip = CLIPDensePredT(version='ViT-B/16', reduce_dim=64, complex_trans_conv=True)
             self.model_clip.eval();
-            self.model_clip.load_state_dict(torch.load('models/CLIP/rd64-uni-refined.pth', map_location=torch.device('cpu')), strict=False)
+            self.model_clip.load_state_dict(torch.load(os.path.join(roop.globals.CFG.models_directory, 'CLIP/rd64-uni-refined.pth'), map_location=torch.device('cpu')), strict=False)
 
         device = torch.device(devicename)
         self.model_clip.to(device)

--- a/roop/processors/frame/face_swapper.py
+++ b/roop/processors/frame/face_swapper.py
@@ -1,5 +1,6 @@
 from typing import Any
 import insightface
+import os
 import threading
 
 import roop.globals
@@ -17,7 +18,7 @@ def get_face_swapper() -> Any:
 
     with THREAD_LOCK:
         if FACE_SWAPPER is None:
-            model_path = resolve_relative_path('../models/inswapper_128.onnx')
+            model_path = os.path.join(roop.globals.CFG.models_directory, 'inswapper_128.onnx')
             FACE_SWAPPER = insightface.model_zoo.get_model(model_path, providers=roop.globals.execution_providers)
     return FACE_SWAPPER
 

--- a/settings.py
+++ b/settings.py
@@ -1,4 +1,5 @@
 import yaml
+import roop.utilities as util
 
 class Settings:
     def __init__(self, config_file):
@@ -12,7 +13,6 @@ class Settings:
         except:
             pass
         return value
-
 
     def load(self):
         try:
@@ -36,10 +36,7 @@ class Settings:
         self.force_cpu = self.default_get(data, 'force_cpu', False)
         self.output_template = self.default_get(data, 'output_template', '{file}_{time}')
         self.use_os_temp_folder = self.default_get(data, 'use_os_temp_folder', False)
-
-
-
-
+        self.models_directory = self.default_get(data, 'models_directory', util.resolve_relative_path('../models'))
 
     def save(self):
         data = {
@@ -47,20 +44,18 @@ class Settings:
             'server_name': self.server_name,
             'server_port': self.server_port,
             'server_share': self.server_share,
-            'output_image_format' : self.output_image_format,
-            'output_video_format' : self.output_video_format,
-            'output_video_codec' : self.output_video_codec,
-            'video_quality' : self.video_quality,
-            'clear_output' : self.clear_output,
-            'max_threads' : self.max_threads,
-            'memory_limit' : self.memory_limit,
-            'provider' : self.provider,
-            'force_cpu' : self.force_cpu,
-			'output_template' : self.output_template,
-            'use_os_temp_folder' : self.use_os_temp_folder
+            'output_image_format': self.output_image_format,
+            'output_video_format': self.output_video_format,
+            'output_video_codec': self.output_video_codec,
+            'video_quality': self.video_quality,
+            'clear_output': self.clear_output,
+            'max_threads': self.max_threads,
+            'memory_limit': self.memory_limit,
+            'provider': self.provider,
+            'force_cpu': self.force_cpu,
+            'output_template': self.output_template,
+            'use_os_temp_folder': self.use_os_temp_folder,
+            'models_directory': self.models_directory,
         }
         with open(self.config_file, 'w') as f:
             yaml.dump(data, f)
-
-
-

--- a/ui/tabs/settings_tab.py
+++ b/ui/tabs/settings_tab.py
@@ -21,6 +21,7 @@ def settings_tab():
         with gr.Row():
             with gr.Column():
                 themes = gr.Dropdown(available_themes, label="Theme", info="Change needs complete restart", value=roop.globals.CFG.selected_theme)
+                input_models_directory = gr.Textbox(label="Models directory", lines=1, info="default: models directory within repo", value=roop.globals.CFG.models_directory)
             with gr.Column():
                 settings_controls.append(gr.Checkbox(label="Public Server", value=roop.globals.CFG.server_share, elem_id='server_share', interactive=True))
                 settings_controls.append(gr.Checkbox(label='Clear output folder before each run', value=roop.globals.CFG.clear_output, elem_id='clear_output', interactive=True))
@@ -60,7 +61,7 @@ def settings_tab():
 
     # button_clean_temp.click(fn=clean_temp, outputs=[bt_srcfiles, input_faces, target_faces, bt_destfiles])
     button_clean_temp.click(fn=clean_temp)
-    button_apply_settings.click(apply_settings, inputs=[themes, input_server_name, input_server_port, output_template])
+    button_apply_settings.click(apply_settings, inputs=[themes, input_server_name, input_server_port, output_template, input_models_directory])
     button_apply_restart.click(restart)
 
 
@@ -113,13 +114,15 @@ def clean_temp():
     return None,None,None,None
 
 
-def apply_settings(themes, input_server_name, input_server_port, output_template):
+def apply_settings(themes, input_server_name, input_server_port, output_template, models_directory):
     from ui.main import show_msg
 
     roop.globals.CFG.selected_theme = themes
     roop.globals.CFG.server_name = input_server_name
     roop.globals.CFG.server_port = input_server_port
     roop.globals.CFG.output_template = output_template
+    roop.globals.CFG.models_directory = models_directory
+
     roop.globals.CFG.save()
     show_msg('Settings saved')
 


### PR DESCRIPTION
This PR introduces the ability for users to configure where the models are saved to. I made this since I like to have a central location for all my AI models that is independent of any repo. 

This was tested using Windows 11. I was able to test all post-processing methods except DMDNet since I don't have an Nvidia GPU

Default models folder is "models" within the repo
![roop-modelsfolder](https://github.com/C0untFloyd/roop-unleashed/assets/1947062/7ab4d932-2f38-4224-aae3-ece5e8a2d3f9)

The UI's Settings tab now has a text box for users to enter the directory path where models will be read from. It's located under the dropdown for Theme selection.
![roop-ui](https://github.com/C0untFloyd/roop-unleashed/assets/1947062/3f407bed-e807-497e-b8d8-63a3dfe4b7d5)

After changing the models directory and reloading, the models were downloaded to my selected directory
![roop-newmodelsfolder](https://github.com/C0untFloyd/roop-unleashed/assets/1947062/16219617-0da8-4bb3-b326-aab103c10c96)

config.yaml with the entry for models_directory
![roop-configfile](https://github.com/C0untFloyd/roop-unleashed/assets/1947062/13001061-2a25-4455-bc25-8b610d50ae17)
