### PR TITLE
add config to control launching browser at startup

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -37,6 +37,7 @@ class Settings:
         self.output_template = self.default_get(data, 'output_template', '{file}_{time}')
         self.use_os_temp_folder = self.default_get(data, 'use_os_temp_folder', False)
         self.output_show_video = self.default_get(data, 'output_show_video', True)
+        self.launch_browser = self.default_get(data, 'launch_browser', True)
 
 
 

--- a/ui/main.py
+++ b/ui/main.py
@@ -72,10 +72,11 @@ def run():
             facemgr_tab()
             extras_tab()
             settings_tab()
+        launch_browser = roop.globals.CFG.launch_browser
 
         uii.ui_restart_server = False
         try:
-            ui.queue().launch(inbrowser=True, server_name=server_name, server_port=server_port, share=roop.globals.CFG.server_share, ssl_verify=ssl_verify, prevent_thread_lock=True, show_error=True)
+            ui.queue().launch(inbrowser=launch_browser, server_name=server_name, server_port=server_port, share=roop.globals.CFG.server_share, ssl_verify=ssl_verify, prevent_thread_lock=True, show_error=True)
         except Exception as e:
             print(f'Exception {e} when launching Gradio Server!')
             uii.ui_restart_server = True


### PR DESCRIPTION
When running headless, like from a terminal, roop-unleashed launches w3m. Add a config setting to control launching the browser at startup. Default is true, no behavior change.