### PR TITLE
Add batch face swap option

### DIFF
--- a/roop/FaceSet.py
+++ b/roop/FaceSet.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 class FaceSet:
+    # The filename of the faceset
+    name = ''
     faces = []
     ref_images = []
     embedding_average = 'None'

--- a/roop/globals.py
+++ b/roop/globals.py
@@ -34,6 +34,8 @@ blend_ratio = 0.5
 distance_threshold = 0.65
 default_det_size = True
 
+loop_through_all_faces = False
+
 no_face_action = 0
 
 processing = False

--- a/roop/utilities.py
+++ b/roop/utilities.py
@@ -124,12 +124,12 @@ def normalize_output_path(source_path: str, target_path: str, output_path: str) 
 
 
 def get_destfilename_from_path(
-    srcfilepath: str, destfilepath: str, extension: str
+    srcfilepath: str, destfilepath: str, extension: str, prefix: str = ""
 ) -> str:
     fn, ext = os.path.splitext(os.path.basename(srcfilepath))
     if "." in extension:
-        return os.path.join(destfilepath, f"{fn}{extension}")
-    return os.path.join(destfilepath, f"{fn}{extension}{ext}")
+        return os.path.join(destfilepath, f"{prefix}{fn}{extension}")
+    return os.path.join(destfilepath, f"{prefix}{fn}{extension}{ext}")
 
 
 def replace_template(file_path: str, index: int = 0) -> str:


### PR DESCRIPTION
### Batch Face Swap Feature

I have the same requirement as issue **#957**, so I have implemented a batch face swap feature.
![圖片](https://github.com/user-attachments/assets/eadfc691-4fd4-4044-a264-166d3f1685b5)
When this toggle box is checked, the feature will loop through all input faces, apply face swapping to all target files (including images and videos), and save the output files with the input face's filename as a prefix.

> **Note:** This feature does not support situations with multiple target faces, such as "Selected Face" mode with multiple targets or "All Input/All Random Faces" mode.

---

### Implementation Details

This feature operates differently for images and videos:

#### 1. **Images**  
- The current selected face index is ignored.  
- All faces are combined with all images and submitted to the swapping queue, starting from face 0.
- The main implementation for this part is located in  [`ProcessMgr.process_frame()`](https://github.com/lead8964878/roop-unleashed/blob/a899b977fcfdac1a73698c1734a9a6401cbe8b5a/roop/ProcessMgr.py#L205C1-L233C29).

#### 2. **Videos**  
- Processing starts from the user's currently selected face and loops through the faces sequentially.  
- For example, if there are three faces and two videos, and the user selects face 1, the processing sequence will be:  
face1_video0, face2_video0, face0_video0, face1_video1, face2_video1, face0_video1
- The main implementation for this part is located in [`core.py`](https://github.com/lead8964878/roop-unleashed/blob/a899b977fcfdac1a73698c1734a9a6401cbe8b5a/roop/core.py#L282C1-L303C41).

---

I have made minimal modifications to the code structure to maintain clarity.

Please review and let me know if there is a better way to approach this feature.  
Thank you very much for this fabulous work!
